### PR TITLE
Change language json schema to be type-safe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,6 @@ keywords = ["bcachefs", "gui", "tools", "gtk", "gtk4"]
 [dependencies]
 gtk4 = "0.7.3"
 include_dir = "0.7.3"
+serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
 sys-locale = "0.3.1"

--- a/src/utils/language.rs
+++ b/src/utils/language.rs
@@ -1,18 +1,16 @@
-use std::collections::HashMap;
 use gtk4::glib::once_cell::sync::Lazy;
 use include_dir::include_dir;
 
 static LANG_DIR: include_dir::Dir = include_dir!("langs");
 
-type LangMap = HashMap<String,String>;
-
 pub static LANG: Lazy<LangMap> = Lazy::new(generate_language);
 
 pub static DEFAULT_LANG: Lazy<LangMap> = Lazy::new(generate_default_language);
 
+const DEFAULT_LANG_LOCALE: &str = "en-us";
+
 fn generate_default_language() -> LangMap {
-    let lang = "en-us";
-    let file = LANG_DIR.get_file(format!("{lang}.json")).unwrap();
+    let file = LANG_DIR.get_file(format!("{DEFAULT_LANG_LOCALE}.json")).unwrap();
     let contents = file.contents_utf8().unwrap();
     serde_json::from_str(contents).unwrap()
 }
@@ -20,10 +18,17 @@ fn generate_default_language() -> LangMap {
 fn generate_language() -> LangMap {
     let lang = sys_locale::get_locale().unwrap_or("en-US".to_string()).to_lowercase();
     let file = LANG_DIR.get_file(format!("{lang}.json"));
-    if file.is_none() {
-        println!("Language {lang} is yet not supported");
-        return generate_default_language();
+    if let Some(file) = file {
+        let contents = file.contents_utf8().unwrap();
+        serde_json::from_str(content).unwrap()
+    } else {
+        println!("Language {lang} is not yet supported");
+        generate_default_language()
     }
-    let contents = file.unwrap().contents_utf8().unwrap();
-    serde_json::from_str(contents).unwrap()
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LangMap {
+    #[serde(rename = "main-window.title")]
+    pub main_window_title: String
 }


### PR DESCRIPTION
You can use serdes "Derive" to pre-structure your json schema so you already have it validated whenever you use it elsewhere.

I'm sorry if this is uncalled for, I just stumbled over your repo and saw you were learning Rust, so I thought about giving you a pointer.

(I really miss serde in Java, it would be very helpful for those Minecraft mods)